### PR TITLE
Fix journal club slides path.

### DIFF
--- a/our-initiatives/journal-club/journal-club-1.md
+++ b/our-initiatives/journal-club/journal-club-1.md
@@ -2,12 +2,11 @@
 sidebar_position: 2
 ---
 
-# Yves-Alexandre de Montjoye: The search for anonymous data 
+# Yves-Alexandre de Montjoye: The search for anonymous data
 
 **Date: 9th October 2023**
 
 ![Yves-Alexandre de Montjoye](/img/jc/journal-1-image.jpeg)
-
 
 The AI Society Journal Club was thrilled to welcome Yves-Alexandre de Montjoye for an enthralling dialogue, centered around the metamorphosis of data anonymity in today's torrent of data, where every action and movement is captured in real-time. 🌐 The influx of large-scale behavioral data has not only enriched our comprehension of individual and societal behaviors, but also ignited serious privacy apprehensions. 🚀
 
@@ -15,4 +14,4 @@ Yves-Alexandre de Montjoye delved into the shortcomings of traditional de-identi
 
 Concluding the session, de Montjoye painted a picture of how the fusion of these avant-garde techniques can facilitate the significant harnessing of large-scale behavioral data while guaranteeing staunch privacy protections for individuals. This session bestowed deep understanding into marrying data utility with privacy conservation, and how the cohesive deployment of modern privacy engineering techniques can lay the groundwork for secure and influential data usage in the flourishing domain of big data. 🌐💡
 
-You can access the **journal club slides** here: 📘 [The search for anonymous data](/jc/the_search_for_anonymous_data.pdf)
+You can access the **journal club slides** here: 📘 [The search for anonymous data](pathname:///jc/the_search_for_anonymous_data.pdf)


### PR DESCRIPTION
This PR fixes the path of journal club 1 slides.

The bug is caused by how Docusaurus creates assets, and a workaround is described in the [this issue](https://github.com/facebook/docusaurus/issues/6282).
Moreover, the [official Docusaurus docs](https://docusaurus.io/docs/advanced/routing#escaping-from-spa-redirects) describe a workaround.